### PR TITLE
Enable dynamic area management

### DIFF
--- a/class-zuzunely-areas-db.php
+++ b/class-zuzunely-areas-db.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Classe para gerenciar banco de dados de Áreas do restaurante
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Zuzunely_Areas_DB {
+    private $areas_table;
+
+    public function __construct() {
+        global $wpdb;
+        $this->areas_table = $wpdb->prefix . 'zuzunely_areas';
+    }
+
+    public function create_tables() {
+        global $wpdb;
+        $charset_collate = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE {$this->areas_table} (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            name varchar(255) NOT NULL,
+            description text NOT NULL,
+            is_active tinyint(1) DEFAULT 1,
+            created_at datetime DEFAULT CURRENT_TIMESTAMP,
+            updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id)
+        ) $charset_collate;";
+        require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        dbDelta($sql);
+    }
+
+    public function insert_area($data) {
+        global $wpdb;
+        $insert = array(
+            'name' => sanitize_text_field($data['name']),
+            'description' => wp_kses_post($data['description']),
+            'is_active' => isset($data['is_active']) ? 1 : 0,
+        );
+        $result = $wpdb->insert($this->areas_table, $insert, array('%s', '%s', '%d'));
+        if ($result === false) {
+            return false;
+        }
+        return $wpdb->insert_id;
+    }
+
+    public function update_area($id, $data) {
+        global $wpdb;
+        $update = array(
+            'name' => sanitize_text_field($data['name']),
+            'description' => wp_kses_post($data['description']),
+            'is_active' => isset($data['is_active']) ? 1 : 0,
+        );
+        $result = $wpdb->update($this->areas_table, $update, array('id' => $id), array('%s', '%s', '%d'), array('%d'));
+        return $result !== false;
+    }
+
+    public function delete_area($id) {
+        global $wpdb;
+        $result = $wpdb->delete($this->areas_table, array('id' => $id), array('%d'));
+        return $result !== false;
+    }
+
+    public function get_area($id) {
+        global $wpdb;
+        return $wpdb->get_row($wpdb->prepare("SELECT * FROM {$this->areas_table} WHERE id = %d", $id), ARRAY_A);
+    }
+
+    public function get_areas($args = array()) {
+        global $wpdb;
+        $defaults = array(
+            'number' => 20,
+            'offset' => 0,
+            'orderby' => 'id',
+            'order' => 'DESC',
+            'include_inactive' => false,
+        );
+        $args = wp_parse_args($args, $defaults);
+        $where = '';
+        if (!$args['include_inactive']) {
+            $where = "WHERE is_active = 1";
+        }
+        $valid_orderby_fields = array('id', 'name', 'created_at');
+        $orderby = in_array($args['orderby'], $valid_orderby_fields) ? $args['orderby'] : 'id';
+        $order = strtoupper($args['order']) === 'ASC' ? 'ASC' : 'DESC';
+        $sql = "SELECT * FROM {$this->areas_table} $where ORDER BY $orderby $order LIMIT %d, %d";
+        return $wpdb->get_results($wpdb->prepare($sql, $args['offset'], $args['number']), ARRAY_A);
+    }
+
+    public function count_areas($include_inactive = false) {
+        global $wpdb;
+        $where = $include_inactive ? '' : "WHERE is_active = 1";
+        return (int)$wpdb->get_var("SELECT COUNT(id) FROM {$this->areas_table} $where");
+    }
+}

--- a/class-zuzunely-areas-list-table.php
+++ b/class-zuzunely-areas-list-table.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Lista de Áreas para admin
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('WP_List_Table')) {
+    require_once(ABSPATH . 'wp-admin/includes/class-wp-list-table.php');
+}
+
+class Zuzunely_Areas_List_Table extends WP_List_Table {
+    public function __construct() {
+        parent::__construct([
+            'singular' => 'area',
+            'plural'   => 'areas',
+            'ajax'     => false,
+        ]);
+    }
+
+    public function get_columns() {
+        return [
+            'cb'         => '<input type="checkbox" />',
+            'name'       => __('Nome', 'zuzunely-restaurant'),
+            'description'=> __('Descrição', 'zuzunely-restaurant'),
+            'is_active'  => __('Status', 'zuzunely-restaurant'),
+            'created_at' => __('Data de Criação', 'zuzunely-restaurant'),
+        ];
+    }
+
+    public function get_sortable_columns() {
+        return [
+            'name'       => ['name', true],
+            'created_at' => ['created_at', true],
+        ];
+    }
+
+    public function prepare_items() {
+        $per_page = 10;
+        $current_page = $this->get_pagenum();
+        $db = new Zuzunely_Areas_DB();
+        $total_items = $db->count_areas(true);
+        $orderby = isset($_REQUEST['orderby']) ? sanitize_text_field($_REQUEST['orderby']) : 'id';
+        $order = isset($_REQUEST['order']) ? sanitize_text_field($_REQUEST['order']) : 'DESC';
+        $this->items = $db->get_areas([
+            'number' => $per_page,
+            'offset' => ($current_page - 1) * $per_page,
+            'orderby'=> $orderby,
+            'order'  => $order,
+            'include_inactive' => true,
+        ]);
+        $this->set_pagination_args([
+            'total_items' => $total_items,
+            'per_page'    => $per_page,
+            'total_pages' => ceil($total_items / $per_page),
+        ]);
+        $this->_column_headers = [$this->get_columns(), [], $this->get_sortable_columns(), 'name'];
+    }
+
+    public function column_cb($item) {
+        return sprintf('<input type="checkbox" name="area_id[]" value="%s" />', $item['id']);
+    }
+
+    public function column_name($item) {
+        $edit_url = admin_url(sprintf('admin.php?page=zuzunely-areas&action=edit&id=%s', $item['id']));
+        $actions = [
+            'edit'   => sprintf('<a href="%s">%s</a>', $edit_url, __('Editar', 'zuzunely-restaurant')),
+        ];
+        return sprintf('<strong><a href="%s">%s</a></strong> %s', $edit_url, $item['name'], $this->row_actions($actions));
+    }
+
+    public function column_description($item) {
+        return wp_trim_words($item['description'], 10, '...');
+    }
+
+    public function column_is_active($item) {
+        return $item['is_active'] ? __('Ativa', 'zuzunely-restaurant') : __('Inativa', 'zuzunely-restaurant');
+    }
+
+    public function column_created_at($item) {
+        $date = new DateTime($item['created_at']);
+        return $date->format(get_option('date_format') . ' ' . get_option('time_format'));
+    }
+
+    public function column_default($item, $column_name) {
+        return isset($item[$column_name]) ? $item[$column_name] : '—';
+    }
+
+    public function get_bulk_actions() {
+        return [
+            'delete' => __('Excluir', 'zuzunely-restaurant'),
+        ];
+    }
+
+    public function no_items() {
+        _e('Nenhuma área encontrada.', 'zuzunely-restaurant');
+    }
+}

--- a/class-zuzunely-areas.php
+++ b/class-zuzunely-areas.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Gestão de Áreas do restaurante
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Zuzunely_Areas {
+    public function __construct() {
+        add_action('wp_ajax_zuzunely_save_area', [$this, 'ajax_save_area']);
+    }
+
+    public static function admin_page() {
+        $action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        switch ($action) {
+            case 'add':
+                self::render_add_edit_form();
+                break;
+            case 'edit':
+                self::render_add_edit_form($id);
+                break;
+            default:
+                self::render_list_table();
+                break;
+        }
+    }
+
+    private static function render_list_table() {
+        if (!class_exists('WP_List_Table')) {
+            require_once(ABSPATH . 'wp-admin/includes/class-wp-list-table.php');
+        }
+        $table = new Zuzunely_Areas_List_Table();
+        $table->prepare_items();
+        ?>
+        <div class="wrap">
+            <h1 class="wp-heading-inline"><?php echo esc_html__('Áreas', 'zuzunely-restaurant'); ?></h1>
+            <a href="<?php echo admin_url('admin.php?page=zuzunely-areas&action=add'); ?>" class="page-title-action"><?php echo esc_html__('Adicionar Nova', 'zuzunely-restaurant'); ?></a>
+            <form method="post">
+                <?php
+                wp_nonce_field('bulk-areas');
+                $table->display();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    private static function render_add_edit_form($id = 0) {
+        $area = ['name' => '', 'description' => '', 'is_active' => 1];
+        $title = __('Adicionar Nova Área', 'zuzunely-restaurant');
+        if ($id > 0) {
+            $db = new Zuzunely_Areas_DB();
+            $loaded = $db->get_area($id);
+            if ($loaded) {
+                $area = $loaded;
+                $title = __('Editar Área', 'zuzunely-restaurant');
+            }
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php echo esc_html($title); ?></h1>
+            <form id="zuzunely-area-form" method="post">
+                <input type="hidden" name="area_id" value="<?php echo $id; ?>">
+                <?php wp_nonce_field('zuzunely_area_nonce', 'zuzunely_nonce'); ?>
+                <table class="form-table">
+                    <tbody>
+                        <tr>
+                            <th scope="row"><label for="area_name"><?php echo esc_html__('Nome', 'zuzunely-restaurant'); ?></label></th>
+                            <td><input type="text" name="area_name" id="area_name" class="regular-text" value="<?php echo esc_attr($area['name']); ?>" required></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="area_description"><?php echo esc_html__('Descrição', 'zuzunely-restaurant'); ?></label></th>
+                            <td><?php wp_editor($area['description'], 'area_description', ['textarea_name' => 'area_description', 'textarea_rows' => 5, 'media_buttons' => false]); ?></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="area_active"><?php echo esc_html__('Status', 'zuzunely-restaurant'); ?></label></th>
+                            <td><label><input type="checkbox" name="area_active" id="area_active" value="1" <?php checked($area['is_active'], 1); ?>> <?php echo esc_html__('Ativa', 'zuzunely-restaurant'); ?></label></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p class="submit">
+                    <button type="submit" class="button button-primary"><?php echo esc_html__('Salvar Área', 'zuzunely-restaurant'); ?></button>
+                    <a href="<?php echo admin_url('admin.php?page=zuzunely-areas'); ?>" class="button button-secondary"><?php echo esc_html__('Cancelar', 'zuzunely-restaurant'); ?></a>
+                </p>
+            </form>
+        </div>
+        <script>
+        jQuery(function($){
+            $('#zuzunely-area-form').on('submit', function(e){
+                e.preventDefault();
+                if (typeof tinyMCE !== 'undefined') { tinyMCE.triggerSave(); }
+                $.ajax({
+                    url: ajaxurl,
+                    type: 'POST',
+                    data: {action:'zuzunely_save_area', form_data: $(this).serialize()},
+                    success:function(r){ if(r.success){ window.location.href='<?php echo admin_url('admin.php?page=zuzunely-areas'); ?>'; } else { alert(r.data); } }
+                });
+            });
+        });
+        </script>
+        <?php
+    }
+
+    public function ajax_save_area() {
+        if (!isset($_POST['form_data'])) {
+            wp_send_json_error(__('Dados do formulário não encontrados.', 'zuzunely-restaurant'));
+        }
+        parse_str($_POST['form_data'], $data);
+        if (!isset($data['zuzunely_nonce']) || !wp_verify_nonce($data['zuzunely_nonce'], 'zuzunely_area_nonce')) {
+            wp_send_json_error(__('Erro de segurança.', 'zuzunely-restaurant'));
+        }
+        $id = isset($data['area_id']) ? intval($data['area_id']) : 0;
+        $name = sanitize_text_field($data['area_name']);
+        $description = wp_kses_post($data['area_description']);
+        $active = isset($data['area_active']) ? 1 : 0;
+        if (empty($name)) {
+            wp_send_json_error(__('Nome da área é obrigatório.', 'zuzunely-restaurant'));
+        }
+        $db = new Zuzunely_Areas_DB();
+        $area_data = ['name'=>$name,'description'=>$description,'is_active'=>$active];
+        if ($id > 0) {
+            $result = $db->update_area($id, $area_data);
+        } else {
+            $result = $db->insert_area($area_data);
+        }
+        if ($result) {
+            wp_send_json_success();
+        } else {
+            wp_send_json_error(__('Erro ao salvar dados.', 'zuzunely-restaurant'));
+        }
+    }
+}

--- a/class-zuzunely-install.php
+++ b/class-zuzunely-install.php
@@ -13,6 +13,10 @@ class Zuzunely_Install {
      * Criar todas as tabelas necessárias
      */
     public static function create_tables() {
+        // Criar tabela de áreas
+        $areas_db = new Zuzunely_Areas_DB();
+        $areas_db->create_tables();
+
         // Criar tabela de salões
         $saloons_db = new Zuzunely_Saloons_DB();
         $saloons_db->create_tables();
@@ -45,6 +49,10 @@ class Zuzunely_Install {
     public static function verify_tables() {
         global $wpdb;
         
+        // Verificar tabela de áreas
+        $areas_table = $wpdb->prefix . 'zuzunely_areas';
+        $areas_exists = $wpdb->get_var("SHOW TABLES LIKE '$areas_table'") === $areas_table;
+
         // Verificar tabela de salões
         $saloons_table = $wpdb->prefix . 'zuzunely_saloons';
         $saloons_exists = $wpdb->get_var("SHOW TABLES LIKE '$saloons_table'") === $saloons_table;
@@ -62,12 +70,19 @@ class Zuzunely_Install {
         $availability_exists = $wpdb->get_var("SHOW TABLES LIKE '$availability_table'") === $availability_table;
         
         // Log da verificação
-        error_log('Zuzunely: Verificação de tabelas - Salões: ' . ($saloons_exists ? 'Existe' : 'Não existe') . 
-                  ', Mesas: ' . ($tables_exists ? 'Existe' : 'Não existe') . 
+        error_log('Zuzunely: Verificação de tabelas - Áreas: ' . ($areas_exists ? 'Existe' : 'Não existe') .
+                  ', Salões: ' . ($saloons_exists ? 'Existe' : 'Não existe') .
+                  ', Mesas: ' . ($tables_exists ? 'Existe' : 'Não existe') .
                   ', Bloqueios: ' . ($blocks_exists ? 'Existe' : 'Não existe') .
                   ', Disponibilidades: ' . ($availability_exists ? 'Existe' : 'Não existe'));
         
         // Criar tabelas faltantes
+        if (!$areas_exists) {
+            $areas_db = new Zuzunely_Areas_DB();
+            $areas_db->create_tables();
+            error_log('Zuzunely: Tabela de áreas criada');
+        }
+
         if (!$saloons_exists) {
             $saloons_db = new Zuzunely_Saloons_DB();
             $saloons_db->create_tables();
@@ -104,11 +119,12 @@ class Zuzunely_Install {
         }
         
         return array(
+            'areas'   => $areas_exists,
             'saloons' => $saloons_exists,
             'tables' => $tables_exists,
             'blocks' => $blocks_exists,
             'availability' => $availability_exists,
-            'created_now' => !$saloons_exists || !$tables_exists || !$blocks_exists || !$availability_exists
+            'created_now' => !$areas_exists || !$saloons_exists || !$tables_exists || !$blocks_exists || !$availability_exists
         );
     }
     

--- a/class-zuzunely-reservations-db.php
+++ b/class-zuzunely-reservations-db.php
@@ -600,10 +600,11 @@ class Zuzunely_Reservations_DB {
         
         Zuzunely_Logger::debug("Buscando mesas disponíveis - Data: {$date}, Hora: {$time}, Pessoas: {$guests_count}, Ignorar regras: " . ($ignore_rules ? 'Sim' : 'Não'));
         
-        // Obter todas as mesas ativas com informação dos salões - CONSULTA CORRIGIDA
-        $tables_sql = "SELECT t.*, s.name as saloon_name, s.is_internal as saloon_is_internal, s.id as saloon_id
+        // Obter todas as mesas ativas com informação dos salões e áreas
+        $tables_sql = "SELECT t.*, s.name as saloon_name, s.area_id as saloon_area_id, a.name as area_name, s.id as saloon_id
                        FROM {$wpdb->prefix}zuzunely_tables t
                        LEFT JOIN {$wpdb->prefix}zuzunely_saloons s ON t.saloon_id = s.id
+                       LEFT JOIN {$wpdb->prefix}zuzunely_areas a ON s.area_id = a.id
                        WHERE t.is_active = 1 AND s.is_active = 1
                        ORDER BY t.name";
         

--- a/class-zuzunely-saloons-db.php
+++ b/class-zuzunely-saloons-db.php
@@ -32,7 +32,7 @@ class Zuzunely_Saloons_DB {
             name varchar(255) NOT NULL,
             description text NOT NULL,
             images longtext,
-            is_internal tinyint(1) DEFAULT 1,
+            area_id mediumint(9) NOT NULL,
             is_active tinyint(1) DEFAULT 1,
             created_at datetime DEFAULT CURRENT_TIMESTAMP,
             updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -68,7 +68,7 @@ class Zuzunely_Saloons_DB {
             'name' => sanitize_text_field($data['name']),
             'description' => wp_kses_post($data['description']),
             'images' => $data['images'],
-            'is_internal' => isset($data['is_internal']) ? 1 : 0,
+            'area_id' => intval($data['area_id']),
             'is_active' => isset($data['is_active']) ? 1 : 0,
         );
         
@@ -107,7 +107,7 @@ class Zuzunely_Saloons_DB {
             'name' => sanitize_text_field($data['name']),
             'description' => wp_kses_post($data['description']),
             'images' => $data['images'],
-            'is_internal' => isset($data['is_internal']) ? 1 : 0,
+            'area_id' => intval($data['area_id']),
             'is_active' => isset($data['is_active']) ? 1 : 0,
         );
         
@@ -157,7 +157,10 @@ class Zuzunely_Saloons_DB {
         
         // Buscar do banco de dados
         $saloon = $wpdb->get_row(
-            $wpdb->prepare("SELECT * FROM {$this->saloons_table} WHERE id = %d", $id),
+            $wpdb->prepare(
+                "SELECT s.*, a.name as area_name FROM {$this->saloons_table} s LEFT JOIN {$wpdb->prefix}zuzunely_areas a ON s.area_id = a.id WHERE s.id = %d",
+                $id
+            ),
             ARRAY_A
         );
         
@@ -197,14 +200,14 @@ class Zuzunely_Saloons_DB {
         }
         
         // Validar campos de ordenação para evitar injeção SQL
-        $valid_orderby_fields = array('id', 'name', 'is_active', 'is_internal', 'created_at', 'updated_at');
+        $valid_orderby_fields = array('id', 'name', 'is_active', 'area_id', 'created_at', 'updated_at');
         $orderby = in_array($args['orderby'], $valid_orderby_fields) ? $args['orderby'] : 'id';
         
         $valid_order = array('ASC', 'DESC');
         $order = in_array(strtoupper($args['order']), $valid_order) ? strtoupper($args['order']) : 'DESC';
         
         // Consulta SQL básica
-        $sql = "SELECT * FROM {$this->saloons_table} $where ORDER BY {$orderby} {$order} LIMIT %d, %d";
+        $sql = "SELECT s.*, a.name as area_name FROM {$this->saloons_table} s LEFT JOIN {$wpdb->prefix}zuzunely_areas a ON s.area_id = a.id $where ORDER BY s.$orderby $order LIMIT %d, %d";
         
         // Log da consulta SQL para depuração
         error_log('SQL para obter salões: ' . $wpdb->prepare($sql, $args['offset'], $args['number']));

--- a/class-zuzunely-saloons-list-table.php
+++ b/class-zuzunely-saloons-list-table.php
@@ -42,7 +42,7 @@ class Zuzunely_Saloons_List_Table extends WP_List_Table {
     public function get_sortable_columns() {
         $sortable_columns = array(
             'name' => array('name', true),
-            'location' => array('is_internal', true),
+            'location' => array('area_id', true),
             'is_active' => array('is_active', true),
             'created_at' => array('created_at', true),
         );
@@ -144,12 +144,8 @@ class Zuzunely_Saloons_List_Table extends WP_List_Table {
     
     // Renderizar coluna de localização
     public function column_location($item) {
-        if (isset($item['is_internal'])) {
-            if ($item['is_internal']) {
-                return '<span class="zuzunely-location zuzunely-location-internal">' . __('Área Interna', 'zuzunely-restaurant') . '</span>';
-            } else {
-                return '<span class="zuzunely-location zuzunely-location-external">' . __('Área Externa', 'zuzunely-restaurant') . '</span>';
-            }
+        if (isset($item['area_name'])) {
+            return esc_html($item['area_name']);
         }
         return '—';
     }

--- a/class-zuzunely-saloons.php
+++ b/class-zuzunely-saloons.php
@@ -165,7 +165,7 @@ class Zuzunely_Saloons {
             'name' => '',
             'description' => '',
             'images' => array(),
-            'is_internal' => 1,
+            'area_id' => 0,
             'is_active' => 1
         );
         
@@ -174,12 +174,15 @@ class Zuzunely_Saloons {
         if ($id > 0) {
             $db = new Zuzunely_Saloons_DB();
             $loaded_saloon = $db->get_saloon($id);
-            
+
             if ($loaded_saloon) {
                 $saloon = $loaded_saloon;
                 $title = __('Editar Salão', 'zuzunely-restaurant');
             }
         }
+
+        $areas_db = new Zuzunely_Areas_DB();
+        $areas = $areas_db->get_areas(['include_inactive' => false, 'number' => 100]);
         
         ?>
         <div class="wrap">
@@ -250,21 +253,16 @@ class Zuzunely_Saloons {
                         
                         <tr>
                             <th scope="row">
-                                <label for="saloon_location"><?php echo esc_html__('Localização', 'zuzunely-restaurant'); ?></label>
+                                <label for="saloon_area_id"><?php echo esc_html__('Área', 'zuzunely-restaurant'); ?></label>
                             </th>
                             <td>
-                                <label>
-                                    <input type="radio" name="saloon_internal" id="saloon_internal_yes" value="1" 
-                                           <?php checked($saloon['is_internal'], 1); ?>>
-                                    <?php echo esc_html__('Área Interna', 'zuzunely-restaurant'); ?>
-                                </label>
-                                <br>
-                                <label>
-                                    <input type="radio" name="saloon_internal" id="saloon_internal_no" value="0" 
-                                           <?php checked($saloon['is_internal'], 0); ?>>
-                                    <?php echo esc_html__('Área Externa', 'zuzunely-restaurant'); ?>
-                                </label>
-                                <p class="description"><?php echo esc_html__('Selecione se o salão fica na área interna ou externa do restaurante.', 'zuzunely-restaurant'); ?></p>
+                                <select name="saloon_area_id" id="saloon_area_id" required>
+                                    <option value=""><?php echo esc_html__('Selecione uma área', 'zuzunely-restaurant'); ?></option>
+                                    <?php foreach ($areas as $area) : ?>
+                                        <option value="<?php echo $area['id']; ?>" <?php selected($saloon['area_id'], $area['id']); ?>><?php echo esc_html($area['name']); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <p class="description"><?php echo esc_html__('Associe o salão a uma área.', 'zuzunely-restaurant'); ?></p>
                             </td>
                         </tr>
                         
@@ -402,7 +400,7 @@ class Zuzunely_Saloons {
         $saloon_name = isset($form_data['saloon_name']) ? sanitize_text_field($form_data['saloon_name']) : '';
         $saloon_description = isset($form_data['saloon_description']) ? wp_kses_post($form_data['saloon_description']) : '';
         $saloon_images = isset($form_data['saloon_images']) ? array_map('intval', $form_data['saloon_images']) : array();
-        $saloon_internal = isset($form_data['saloon_internal']) ? intval($form_data['saloon_internal']) : 1;
+        $saloon_area_id = isset($form_data['saloon_area_id']) ? intval($form_data['saloon_area_id']) : 0;
         $saloon_active = isset($form_data['saloon_active']) ? 1 : 0;
         
         // Validar nome
@@ -415,7 +413,7 @@ class Zuzunely_Saloons {
             'name' => $saloon_name,
             'description' => $saloon_description,
             'images' => $saloon_images,
-            'is_internal' => $saloon_internal,
+            'area_id' => $saloon_area_id,
             'is_active' => $saloon_active
         );
         

--- a/class-zuzunely-tables-db.php
+++ b/class-zuzunely-tables-db.php
@@ -204,12 +204,13 @@ class Zuzunely_Tables_DB {
         $valid_order = array('ASC', 'DESC');
         $order = in_array(strtoupper($args['order']), $valid_order) ? strtoupper($args['order']) : 'DESC';
         
-        // Consulta SQL básica - CORRIGIDA PARA INCLUIR is_internal
-        $sql = "SELECT t.*, s.name as saloon_name, s.is_internal as saloon_is_internal, s.id as saloon_id
+        // Consulta SQL básica - inclui área do salão
+        $sql = "SELECT t.*, s.name as saloon_name, s.area_id as saloon_area_id, a.name as area_name, s.id as saloon_id
                 FROM {$this->tables_table} t
                 LEFT JOIN {$wpdb->prefix}zuzunely_saloons s ON t.saloon_id = s.id
-                $where_clause 
-                ORDER BY t.$orderby $order 
+                LEFT JOIN {$wpdb->prefix}zuzunely_areas a ON s.area_id = a.id
+                $where_clause
+                ORDER BY t.$orderby $order
                 LIMIT %d, %d";
         
         // Log da consulta SQL para depuração

--- a/frontend-reservations.js
+++ b/frontend-reservations.js
@@ -24,8 +24,10 @@ jQuery(document).ready(function($) {
         // Seleção de área (modo área)
         $(document).on('change', 'input[name="area_selection"]', function() {
             if ($(this).is(':checked')) {
-                var areaType = $(this).val();
-                $('#selected_area').val(areaType);
+                var areaId = $(this).val();
+                var areaName = $(this).data('area-name');
+                $('#selected_area').val(areaId);
+                $('#selected_area').data('area-name', areaName);
                 $('#continue-to-step3').prop('disabled', false);
             }
         });
@@ -438,8 +440,7 @@ jQuery(document).ready(function($) {
         } else if (selectionMode === 'area') {
             var selectedArea = $('input[name="area_selection"]:checked');
             if (selectedArea.length > 0) {
-                var areaType = selectedArea.val();
-                var areaName = areaType === 'internal' ? 'Área Interna' : 'Área Externa';
+                var areaName = selectedArea.data('area-name');
                 summaryHtml += '<p><strong>Área:</strong> ' + areaName + ' (mesa será escolhida automaticamente)</p>';
             } else {
                 summaryHtml += '<p><strong>Local:</strong> Mesa será escolhida automaticamente</p>';
@@ -579,7 +580,7 @@ jQuery(document).ready(function($) {
     function resetForm() {
         $('#zuzunely-frontend-form')[0].reset();
         $('#selected_table_id').val('');
-        $('#selected_area').val('');
+        $('#selected_area').val('').data('area-name', '');
         $('#available-tables-container').html('<p>Use o botão acima para ver as opções disponíveis.</p>');
         $('#continue-to-step3').prop('disabled', true);
         $('#reservation-summary').empty();


### PR DESCRIPTION
## Summary
- introduce `Zuzunely_Areas_DB` and related admin classes
- create areas table on install and link saloons to areas
- update saloon forms and listings to use dynamic areas
- join area info when listing saloons, tables and reservations
- adapt frontend to select areas dynamically

## Testing
- `php -l class-zuzunely-areas-db.php`
- `php -l class-zuzunely-areas-list-table.php`
- `php -l class-zuzunely-areas.php`
- `php -l class-zuzunely-install.php`
- `php -l class-zuzunely-saloons-db.php`
- `php -l class-zuzunely-saloons.php`
- `php -l class-zuzunely-saloons-list-table.php`
- `php -l class-zuzunely-tables-db.php`
- `php -l class-zuzunely-reservations-db.php`
- `php -l class-zuzunely-frontend-reservations.php`
- `node -c frontend-reservations.js`

------
https://chatgpt.com/codex/tasks/task_e_68823835bfdc832a81666f2b678be94b